### PR TITLE
Support empty search term

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ def index():
 def contacts():
     search = request.args.get("q")
     page = int(request.args.get("page", 1))
-    if search:
+    if search is not None:
         contacts_set = Contact.search(search)
         if request.headers.get('HX-Trigger') == 'search':
             return render_template("rows.html", contacts=contacts_set, page=page)


### PR DESCRIPTION
Fix bug where the backend was selecting the `index.html` template instead of `rows.html` when the search string was empty.