### PR TITLE
Fix missing CSS

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,7 +2,7 @@
 <html lang="">
 <head>
     <title>Contact App</title>
-    <link rel="stylesheet" href="https://the.missing.style/v0.2.0/missing.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/missing.css@1.0.12/dist/missing.min.css">
     <link rel="stylesheet" href="/static/site.css">
     <script src="/static/js/htmx-1.8.0.js"></script>
     <script src="/static/js/_hyperscript-0.9.7.js"></script>


### PR DESCRIPTION
The Missing Style was, unironcally, missing from its URL. Updated with the version found linked from https://hypermedia.systems/hypermedia-systems/